### PR TITLE
META.info: do not use SSH URL

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,5 +4,5 @@
     "description" : "Resize images using GD",
     "author"      : "Dagur Valberg Johannsson",
     "depends"     : ["GD::Raw"],
-    "source-url"  : "git@github.com:dagurval/perl6-image-resize.git"
+    "source-url"  : "git://github.com/dagurval/perl6-image-resize.git"
 }


### PR DESCRIPTION
only registered github users can use SSH URLs, but we want everybody to be able to use panda to install modules.
