### PR TITLE
Use `basename` on IO::Path object directly

### DIFF
--- a/lib/Image/Resize.pm6
+++ b/lib/Image/Resize.pm6
@@ -58,7 +58,7 @@ class Image::Resize {
 
 
     method !get-ext($path) {
-        $path.IO.path.basename ~~ /'.' (\w+)/;
+        $path.IO.basename ~~ /'.' (\w+)/;
         my Str $ext = ~$/[0];
         die "Path '$path' is missing image extension (.png, .jpg etc.)"
             unless $ext;


### PR DESCRIPTION
It is no longer necessary to extract the path from an `IO` object in order
to request such information as the basename.  This now works directly on the
`IO::Path` which is returned when using the `IO` role on a path-like string.
This change corrects this issue and removes one source of errors in the test
suite.