### PR TITLE
Replace tmpdir with $*TMPDIR

### DIFF
--- a/t/common.pm6
+++ b/t/common.pm6
@@ -15,7 +15,7 @@ sub get-png-size($path) is export {
 
 my @to-delete;
 sub tmp-file($ext) is export {
-    my $path = IO::Path.new(IO::Spec.tmpdir);
+    my $path = $*TMPDIR;
     $path = $path.child( ('a'..'z', 'A'..'Z').pick(10).join ~ ".$ext" );
 
     push @to-delete, $path;


### PR DESCRIPTION
IO::Spec.tmpdir is deprecated in favour of $*TMPDIR.  This change uses the
new form of finding the temporary directory.