### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Image/Resize.pm6
+++ b/lib/Image/Resize.pm6
@@ -1,6 +1,6 @@
 use GD::Raw;
 
-module Image::Resize;
+unit module Image::Resize;
 
 class Image::Resize {
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.