### PR TITLE
Remove braces from hash assignment

### DIFF
--- a/lib/Image/Resize.pm6
+++ b/lib/Image/Resize.pm6
@@ -76,13 +76,12 @@ class Image::Resize {
             or die "unable to open $!img-path for reading";
 
         my $ext = self!get-ext($!img-path);
-        my %ext-to-func = {
+        my %ext-to-func =
             bmp => &gdImageCreateFromBmp,
             jpg => &gdImageCreateFromJpeg,
             jpeg => &gdImageCreateFromJpeg,
             gif => &gdImageCreateFromGif,
-            png => &gdImageCreateFromPng
-        };
+            png => &gdImageCreateFromPng;
 
         {
             $!src-img = %ext-to-func{$ext}($fh) or {


### PR DESCRIPTION
Braces in hash assignments (like in Perl5) are deprecated.  This change
corrects this issue, removes a deprecation warning and means the module will
still work after the 2015.07 Rakudo release.