### PR TITLE
Remove `.clean()` from resize() with factor arg

### DIFF
--- a/lib/Image/Resize.pm6
+++ b/lib/Image/Resize.pm6
@@ -139,7 +139,7 @@ multi sub resize-image(Cool $src-img, Cool $dst-img, $factor,
         :$no-resample, :$jpeg-quality) is export {
 
     Image::Resize.new($src-img).resize(
-            $dst-img, $factor, :$no-resample, :$jpeg-quality).clean();
+            $dst-img, $factor, :$no-resample, :$jpeg-quality);
 }
 
 =begin pod


### PR DESCRIPTION
The tests were failing with this error:

GD Warning: one parameter to a memory allocation multiplication is negative
or zero, failing operation gracefully

This is because the width and height values were effectively arbitrary and
it looked like the pointer was being used which was pointing to freed
memory.  Upon closer inspection, I noticed that the `resize` multi method
which is pointed to from the `resize` sub passes control to a more general
`resize` multimethod and within this method the image object is being
destroyed.  Even though the `.clean` method checks for the existence of an
image object before trying to destroy it again, it seems that it was calling
`gdImageDestroy()` an extra time, thus causing this problem.  Nevertheless,
removing the trailing `.clean()` makes the test suite run to completion and
the tests all pass.

Please review this patch as it's entirely possible that further issues of this kind are lurking within the code which I have missed since I'm not very familiar with it.  What's weird about this change is that the `.clean()` is still necessary on the `resize` method which takes width and height as arguments, however removing `.clean()` from the `resize` method taking a factor actually made everything work.