### PR TITLE
Fix sporadic test failures

### DIFF
--- a/t/common.pm6
+++ b/t/common.pm6
@@ -16,7 +16,7 @@ sub get-png-size($path) is export {
 my @to-delete;
 sub tmp-file($ext) is export {
     my $path = $*TMPDIR;
-    $path = $path.child( ('a'..'z', 'A'..'Z').pick(10).join ~ ".$ext" );
+    $path = $path.child( ('a'..'z', 'A'..'Z').flat.pick(10).join ~ ".$ext" );
 
     push @to-delete, $path;
     return $path.Str;


### PR DESCRIPTION
The tests for this module fail sporadically. Usually it's `t/01-resize.t` that fails, but sometimes it's `t/02-more.t`. Researching the problem showed that the `tmp-file` function in `t/common.p6` was always returning the same filename of:
`/tmp/a b c d e f g h i j k l m n o p q r s t u v w x y zA B C D E F G H I J K L M N O P Q R S T U V W X Y Z.png`.

Changing that function to flatten its list of valid characters seems to fix the sporadic failures.